### PR TITLE
ci(workflows): disable automatic setup-node caching

### DIFF
--- a/.github/workflows/publish-npm-manual.yml
+++ b/.github/workflows/publish-npm-manual.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org/"
           node-version-file: "./pkg/package.json"
+          package-manager-cache: false
 
       - name: Test Publish
         if: ${{ ! inputs.publish }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org/"
           node-version-file: "./pkg/package.json"
+          package-manager-cache: false
 
       - name: Publish
         working-directory: ./pkg


### PR DESCRIPTION
### Description

Sets `package-manager-cache: false` to all `actions/setup-node` workflow steps that don't already have caching configured via either `package-manager-cache` or `cache`.

### Motivation

The new default behavior introduced in [`actions/setup-node v5.0.0`](https://github.com/actions/setup-node/releases/tag/v5.0.0) is not safe.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
