### PR TITLE
ci(CODEOWNERS): add Engineering for deps + replace core-dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------
-# DEFAULT OWNERS
+# CODEOWNERS
 # ----------------------------------------------------------------------------
-*    @mdn/core-dev
+# Order is important. The last matching pattern takes precedence.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# ----------------------------------------------------------------------------
 
-# These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
-# If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
-/Cargo.lock @mdn-bot
-/Cargo.toml @mdn-bot
+* @mdn/engineering
+
+/Cargo.lock @mdn/engineering @mdn-bot
+/Cargo.toml @mdn/engineering @mdn-bot


### PR DESCRIPTION
### Description

Updates the CODEOWNERS file to ensure:
- `/.github/workflows/` is owned by `@mdn/engineering`
- `/.github/CODEOWNERS` is owned by the default code owner and `@mdn/engineering`

### Motivation

Ensures the engineering team has oversight of workflow changes, and CODEOWNERS file modifications across repositories.

### Additional details

See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/888.